### PR TITLE
Change the syntax for stacks address literals to require an apostroph…

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -198,8 +198,8 @@ To mint, burn, transfer, etc these tokens, see the [system calls](#system-calls)
 ```
 persist updown as fungible-token with total-supply=u1000000;
 
-const alice = SP2JPBTPVXN7V5N0SH7ZP95GM1GTFVT8SKVAW3R77;
-const bob = SP3WT3PT3NA5SWW82DZ8ZFK8RN412AD3KR5Q7Q3K4;
+const alice = 'SP2JPBTPVXN7V5N0SH7ZP95GM1GTFVT8SKVAW3R77;
+const bob = 'SP3WT3PT3NA5SWW82DZ8ZFK8RN412AD3KR5Q7Q3K4;
 
 public function mint-and-give() {
     updown.mint?(u100, alice);
@@ -233,8 +233,8 @@ To mint, burn, transfer, etc these tokens, see the [system calls](#system-calls)
 ```
 persist nifty as nonfungible-token identified by string[50];
 
-const alice = SP2JPBTPVXN7V5N0SH7ZP95GM1GTFVT8SKVAW3R77;
-const bob = SP3WT3PT3NA5SWW82DZ8ZFK8RN412AD3KR5Q7Q3K4;
+const alice = 'SP2JPBTPVXN7V5N0SH7ZP95GM1GTFVT8SKVAW3R77;
+const bob = 'SP3WT3PT3NA5SWW82DZ8ZFK8RN412AD3KR5Q7Q3K4;
 
 public function mint-and-give() {
     nifty.mint?("roo", alice);
@@ -324,7 +324,7 @@ The import file contains declarations that allow other contracts to access it's 
 
 The first import statement requires a CONTRACT-ID and ID.
 
-CONTRACT-ID is an abolute or relative contract principal. eg. "ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.contract-name" or ".contract-name", respectively. And, ID is an identifier used to refer to the contract in the program.
+CONTRACT-ID is an abolute or relative contract principal. eg. "'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.contract-name" or ".contract-name", respectively. And, ID is an identifier used to refer to the contract in the program.
 
 The definitions of the imported file will be assocated with the contract-id specified. At deployment time, the contract must exist and contain those definitions or Stacks will reject the contract.
 
@@ -588,7 +588,7 @@ Crystalscript supports all the same types as Clarity. Strings default to utf-8. 
 | int  | Signed whole number |   [-]{digits}             | const n = -10; |
 | uint | Unsigned positive whole number|"u"{digits}       | const n = u5; |
 | bool | Boolean true/false | true or false | const b = true; |
-| principal | relative or absolute contract id | .contract or stacks-address.contract | const p = .mycontract; const p2 = ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.mycontract; |
+| principal | relative or absolute contract id | .contract or 'stacks-address.contract | const p = .mycontract; const p2 = 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.mycontract; |
 
 #### Sequence types
 

--- a/src/ast_import_file.js
+++ b/src/ast_import_file.js
@@ -29,6 +29,7 @@ import {
     equal_types,
     pretty_args,
     pretty_type,
+    pretty_principal,
 } from './ast_util.js';
 
 import compiler from './crystal-ast.cjs';
@@ -62,7 +63,7 @@ export function generate_import_file(ast, contract_name, output_cb) {
             equal_types(definition.expr, { type: 'trait_def' }))
         {
             var trait_def = definition.expr.decl;
-            trait_impl_output.push(`    implements trait ${trait_def.contract_id.val}.${trait_def.id},\n`);
+            trait_impl_output.push(`    implements trait ${pretty_principal(trait_def.contract_id.val)}.${trait_def.id},\n`);
         }
     });
     
@@ -72,7 +73,7 @@ export function generate_import_file(ast, contract_name, output_cb) {
             definition.vis=='public' || definition.vis=='read-only'))
         {
             if (definition.trait_def)
-                extern_output.push(`    // member of trait ${definition.trait_def.contract_id.val}.${definition.trait_def.id}\n`);
+                extern_output.push(`    // member of trait ${pretty_principal(definition.trait_def.contract_id.val)}.${definition.trait_def.id}\n`);
             extern_output.push(`    ${func_signature_as_text(definition)},\n`);
         }
         
@@ -128,6 +129,7 @@ export function compile_import_file(opts, fn, contract_id, as_id) {
                 var val = lookup[opts.compile.network] ||
                     lookup["default"];
                 if (val) {
+                    if (/^'/.test(val)) val=val.substr(1);
                     contract_id = { op:'lit', type:'string', val };
                     contract_id_from_json = true;
                 }

--- a/src/ast_util.js
+++ b/src/ast_util.js
@@ -729,6 +729,11 @@ export function pretty_op(node) {
     return node.op;
 }
 
+export function pretty_principal(principal) {
+    if (/^\./.test(principal)) return principal;
+    return "'" + principal;
+}
+
 export function find_first_return(body) {
     var found = null;
     walk_cb(body, node => {

--- a/src/crystal-ast.cjs
+++ b/src/crystal-ast.cjs
@@ -402,7 +402,7 @@ case 185:
  this.$ = {op:'lit', type:'none', line:getLine(this._$), subtype:'keyword', val:yytext }; 
 break;
 case 186:
- this.$={ op:'lit', type:'principal', line:getLine(this._$), val:$$[$0] }; 
+ this.$={ op:'lit', type:'principal', line:getLine(this._$), val:$$[$0].substr(1) }; 
 break;
 case 193:
  this.$ = {op:'lit', type:'string', line:getLine(this._$), size:BigInt(yytext.length-2), val:yytext.substring(1,yytext.length-1) }; 
@@ -432,7 +432,7 @@ case 206:
  this.$ = [$$[$0]] 
 break;
 case 208:
- this.$=$$[$0]; this.$.val = $$[$0-1] + this.$.val; 
+ this.$=$$[$0]; this.$.val = $$[$0-1].substr(1) + this.$.val; 
 break;
 case 210:
  this.$=$$[$0]; this.$.val = '.' + $$[$0-1] + this.$.val; 
@@ -1127,7 +1127,7 @@ case 90:console.log(yy_.yytext);
 break;
 }
 },
-rules: [/^(?:\/\/.*)/,/^(?:import)/,/^(?:const)/,/^(?:private)/,/^(?:public)/,/^(?:readonly)/,/^(?:function)/,/^(?:persist)/,/^(?:declare)/,/^(?:extern)/,/^(?:define)/,/^(?:use)/,/^(?:as)/,/^(?:trait)/,/^(?:implement)/,/^(?:implements)/,/^(?:fungible-token)/,/^(?:nonfungible-token)/,/^(?:if)/,/^(?:else)/,/^(?:return)/,/^(?:foreach)/,/^(?:_countof)/,/^(?:_typeof)/,/^(?:list)/,/^(?:int)/,/^(?:uint)/,/^(?:bool)/,/^(?:string-ascii)/,/^(?:string-utf8)/,/^(?:string)/,/^(?:principal)/,/^(?:response)/,/^(?:buff)/,/^(?:optional)/,/^(?:delete)/,/^(?:true)/,/^(?:false)/,/^(?:none)/,/^(?:contract-caller)/,/^(?:tx-sender)/,/^(?:block-height)/,/^(?:burn-block-height)/,/^(?:stx-liquid-supply)/,/^(?:is-in-regtest)/,/^(?:([0-9])+)/,/^(?:u([0-9])+)/,/^(?:0x([0-9A-Fa-f])*)/,/^(?:([S][A-Z0-9]{39,40}))/,/^(?:([a-zA-Z][a-zA-Z0-9-_]*[!?]{0,1}))/,/^(?:("(?:[^"\\]|\\.)*"))/,/^(?:\+)/,/^(?:-)/,/^(?:\*)/,/^(?:\/)/,/^(?:%)/,/^(?:\*\*)/,/^(?:\^)/,/^(?:~)/,/^(?:&)/,/^(?:\|)/,/^(?:<<)/,/^(?:>>)/,/^(?:>=)/,/^(?:<=)/,/^(?:>)/,/^(?:<)/,/^(?:==)/,/^(?:!=)/,/^(?:\?=)/,/^(?:=)/,/^(?:&&)/,/^(?:\|\|)/,/^(?:!)/,/^(?:#)/,/^(?:\.)/,/^(?::)/,/^(?:;)/,/^(?:,)/,/^(?:\()/,/^(?:\))/,/^(?:\{)/,/^(?:\})/,/^(?:\[)/,/^(?:\])/,/^(?:\?)/,/^(?:=>)/,/^(?:\s+)/,/^(?:.)/,/^(?:$)/,/^(?:.)/],
+rules: [/^(?:\/\/.*)/,/^(?:import)/,/^(?:const)/,/^(?:private)/,/^(?:public)/,/^(?:readonly)/,/^(?:function)/,/^(?:persist)/,/^(?:declare)/,/^(?:extern)/,/^(?:define)/,/^(?:use)/,/^(?:as)/,/^(?:trait)/,/^(?:implement)/,/^(?:implements)/,/^(?:fungible-token)/,/^(?:nonfungible-token)/,/^(?:if)/,/^(?:else)/,/^(?:return)/,/^(?:foreach)/,/^(?:_countof)/,/^(?:_typeof)/,/^(?:list)/,/^(?:int)/,/^(?:uint)/,/^(?:bool)/,/^(?:string-ascii)/,/^(?:string-utf8)/,/^(?:string)/,/^(?:principal)/,/^(?:response)/,/^(?:buff)/,/^(?:optional)/,/^(?:delete)/,/^(?:true)/,/^(?:false)/,/^(?:none)/,/^(?:contract-caller)/,/^(?:tx-sender)/,/^(?:block-height)/,/^(?:burn-block-height)/,/^(?:stx-liquid-supply)/,/^(?:is-in-regtest)/,/^(?:([0-9])+)/,/^(?:u([0-9])+)/,/^(?:0x([0-9A-Fa-f])*)/,/^(?:([\'][S][A-Z0-9]+))/,/^(?:([a-zA-Z][a-zA-Z0-9-_]*[!?]{0,1}))/,/^(?:("(?:[^"\\]|\\.)*"))/,/^(?:\+)/,/^(?:-)/,/^(?:\*)/,/^(?:\/)/,/^(?:%)/,/^(?:\*\*)/,/^(?:\^)/,/^(?:~)/,/^(?:&)/,/^(?:\|)/,/^(?:<<)/,/^(?:>>)/,/^(?:>=)/,/^(?:<=)/,/^(?:>)/,/^(?:<)/,/^(?:==)/,/^(?:!=)/,/^(?:\?=)/,/^(?:=)/,/^(?:&&)/,/^(?:\|\|)/,/^(?:!)/,/^(?:#)/,/^(?:\.)/,/^(?::)/,/^(?:;)/,/^(?:,)/,/^(?:\()/,/^(?:\))/,/^(?:\{)/,/^(?:\})/,/^(?:\[)/,/^(?:\])/,/^(?:\?)/,/^(?:=>)/,/^(?:\s+)/,/^(?:.)/,/^(?:$)/,/^(?:.)/],
 conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90],"inclusive":true}}
 });
 return lexer;

--- a/src/crystal-ast.jison
+++ b/src/crystal-ast.jison
@@ -532,7 +532,7 @@ literal
     | NONE
       {{ $$ = {op:'lit', type:'none', line:getLine(this._$), subtype:'keyword', val:yytext }; }}
     | STX_ADDRESS
-      {{ $$={ op:'lit', type:'principal', line:getLine(this._$), val:$1 }; }}
+      {{ $$={ op:'lit', type:'principal', line:getLine(this._$), val:$1.substr(1) }; }}
     | string_literal
     | int_literal
     | bool_literal
@@ -599,7 +599,7 @@ list_literal_vals
 
 contract_id
     : STX_ADDRESS contract_id_relative
-      {{ $$=$2; $$.val = $1 + $$.val; }}
+      {{ $$=$2; $$.val = $1.substr(1) + $$.val; }}
     | contract_id_relative
     ;
 

--- a/src/crystal-ast.jisonlex
+++ b/src/crystal-ast.jisonlex
@@ -19,7 +19,8 @@ digit                       [0-9]
 hex_digit                   [0-9A-Fa-f]
 id                          [a-zA-Z][a-zA-Z0-9-_]*[!?]{0,1}
 quoted_string               \"(?:[^"\\]|\\.)*\"
-stx_address                 [S][A-Z0-9]{39,40}
+stx_address                 [\'][S][A-Z0-9]+
+//stx_address                 [S][A-Z0-9]{39,40}
 
 %%
 

--- a/tests/contract-call/cc1.2.crystal
+++ b/tests/contract-call/cc1.2.crystal
@@ -1,10 +1,10 @@
 
 import .cc11 from "./cc11.import" as basic1;
 
-import ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.cc11 from
+import 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.cc11 from
        "./cc11.import" as basic1_1;
 
-declare extern ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.cc11 as basic1_2 {
+declare extern 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.cc11 as basic1_2 {
     public function hello-times2(int) => response<int,>
 };
 

--- a/tests/literals.crystal
+++ b/tests/literals.crystal
@@ -19,9 +19,9 @@ public function fn() {
     const mymap = { k1:1, k2:"abc", k3:tx-sender, k5:u99, k6:false, k7:0x5600, k8:{ boo:"boo"} };
 
     const rel_contract_addr = .some-fn;
-    const abs_contract_addr = ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.some-fun;
+    const abs_contract_addr = 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.some-fun;
     const abs_contract_addr2 = principal("ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.some-fun");
-    const stx_addr = ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P;
+    const stx_addr = 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P;
     const stx_addr2 = principal("ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P");
     const stx_addr3 = principal("ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P".ascii());
 

--- a/tests/persist/ft.crystal
+++ b/tests/persist/ft.crystal
@@ -35,7 +35,7 @@ public function ftx-burn(amt uint, p principal) {
     const r =
           ftx.burn?(amt -1, p);
     const siphon =
-          ftx.transfer?(u1, p, SP12Z1TE686409JC1DVE32V7CTW98Q4KWCCFNY2KB);
+          ftx.transfer?(u1, p, 'SP12Z1TE686409JC1DVE32V7CTW98Q4KWCCFNY2KB);
     return r.isok() && siphon.isok() ? getbal(p) : err(r.errval);
 }
 // TEST: ftx-burn(u100, 'SPMP5QFV2GB8SG0P92QH6XEA9PKBETNN5HV0N303) => ok: val.balance.value == 100 && val.supply.value == 101

--- a/tests/syscall/is-standard.crystal
+++ b/tests/syscall/is-standard.crystal
@@ -4,8 +4,8 @@ public function test() {
     // on testnet.  b1 and b2 should be true on testnet, false on
     // mainnet.  the dev environment with clarity-cli is returning
     // false (mainnet)
-    const b1 = is-standard(STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6);
-    const b2 = is-standard(STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.foo);
+    const b1 = is-standard('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6);
+    const b2 = is-standard('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.foo);
     return ok({
         b1:b1,
         b2:b2

--- a/tests/syscall/principal-construct.crystal
+++ b/tests/syscall/principal-construct.crystal
@@ -10,8 +10,8 @@ public function pc() {
         "foo".ascii()
     );
 
-    const pd1 = principal-destruct?(SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY);
-    const pd2 = principal-destruct?(SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY.foo);
+    const pd1 = principal-destruct?('SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY);
+    const pd2 = principal-destruct?('SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY.foo);
 
     const all_ok = p1.isok() &&
           p2.isok() &&

--- a/tests/trait/trait1.5.crystal
+++ b/tests/trait/trait1.5.crystal
@@ -1,5 +1,5 @@
 
-import ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.mycontract
+import 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.mycontract
     from "./mycontract.import" as mycontract;
 
 implement trait mycontract.name-trait;

--- a/tests/trait/trait1.6.crystal
+++ b/tests/trait/trait1.6.crystal
@@ -3,7 +3,7 @@
 import .mycontract from "./mycontract.import" as mycontract;
 
 // implements "name-trait"
-import ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.trait13
+import 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.trait13
     from "./trait13.import" as trait13-contract;
 
 public function callme(contract trait<mycontract.name-trait>, str string[5]) {

--- a/tests/trait/trait1.7.crystal
+++ b/tests/trait/trait1.7.crystal
@@ -2,7 +2,7 @@
 import .mycontract from "./mycontract.import" as mycontract;
 
 // implements "name-trait"
-import ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.trait13
+import 'ST26FVX16539KKXZKJN098Q08HRX3XBAP541MFS0P.trait13
     from "./trait13.import" as trait13-contract;
 
 // should not be allowed: using contract id syntax to identify the trait


### PR DESCRIPTION
…e (tick mark) in front of the address, just like Clarity (eg: 'SP2JPBTPVXN7V5N0SH7ZP95GM1GTFVT8SKVAW3R77 vs old broken syntax SP2JPBTPVXN7V5N0SH7ZP95GM1GTFVT8SKVAW3R77)